### PR TITLE
Added check for a usable DirectionsIterator

### DIFF
--- a/lib/pages/confirm_page.dart
+++ b/lib/pages/confirm_page.dart
@@ -104,13 +104,29 @@ class _ConfirmPageState extends State<ConfirmPage> {
                         SizedBox(height: 25),
                         TextButton(
                           onPressed: () {
-                            Navigator.pushNamed(context, NavigationPage.id,
-                                arguments: [
-                                  _position,
-                                  _current,
-                                  _destination,
-                                  _directions
-                                ]);
+                            if (DirectionsIterator(_directions).isGood()) {
+                              Navigator.pushNamed(context, NavigationPage.id,
+                                  arguments: [
+                                    _position,
+                                    _current,
+                                    _destination,
+                                    _directions
+                                  ]);
+                            } else {
+                              showDialog<String>(
+                                context: context,
+                                builder: (BuildContext context) => AlertDialog(
+                                  title: const Text('No Route Found'),
+                                  content: const Text('Please try again'),
+                                  actions: <Widget>[
+                                    TextButton(
+                                      onPressed: () => Navigator.pop(context, 'OK'),
+                                      child: const Text('OK'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            }
                           },
                           style: kBlueButtonStyle,
                           child: Padding(


### PR DESCRIPTION
I wasn't able to get the pop-up to trigger, but it appears that the check for isGood() does work and the alert that would otherwise show up is the same format as Flutter's example.